### PR TITLE
add missing dependency(Git::Repository::Plugin::Log)

### DIFF
--- a/META.json
+++ b/META.json
@@ -48,6 +48,7 @@
       "runtime" : {
          "requires" : {
             "Git::Repository" : "0",
+            "Git::Repository::Plugin::Log" : "0",
             "parent" : "0",
             "perl" : "5.008001"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'Git::Repository';
+requires 'Git::Repository::Plugin::Log';
 requires 'parent';
 requires 'perl', '5.006';
 


### PR DESCRIPTION
Installing Git::Repository::FileHistory failed in my environment. It seems to miss dependency to Git::Repository::Plugin::Log.

Here is the log when install is failed.

$ less /home/tsucchi/.cpanm/build.log
cpanm (App::cpanminus) 1.6911 on perl 5.019007 built for x86_64-linux
Work directory is /home/tsucchi/.cpanm/work/1388109363.696
You have make /usr/bin/make
You have LWP 6.05
You have /bin/tar: tar (GNU tar) 1.23
Copyright (C) 2010 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by John Gilmore and Jay Fenlason.
You have /usr/bin/unzip
Searching Git::Repository::FileHistory on cpanmetadb ...
--> Working on Git::Repository::FileHistory
Fetching http://www.cpan.org/authors/id/S/SO/SONGMU/Git-Repository-FileHistory-0.03.tar.gz
-> OK
Unpacking Git-Repository-FileHistory-0.03.tar.gz
Entering Git-Repository-FileHistory-0.03
Checking configure dependencies from META.json
Checking if you have CPAN::Meta::Prereqs 0 ... Yes (2.133380)
Checking if you have CPAN::Meta 0 ... Yes (2.133380)
Checking if you have Module::Build 0.38 ... Yes (0.4203)
Configuring Git-Repository-FileHistory-0.03
Running Build.PL
Created MYMETA.yml and MYMETA.json
Creating new 'Build' script for 'Git-Repository-FileHistory' version '0.03'
Merging cpanfile prereqs to MYMETA.yml
Merging cpanfile prereqs to MYMETA.json
-> OK
Checking dependencies from MYMETA.json ...
Checking if you have parent 0 ... Yes (0.228)
Checking if you have ExtUtils::CBuilder 0 ... Yes (0.280212)
Checking if you have ExtUtils::MakeMaker 6.59 ... Yes (6.84)
Checking if you have Git::Repository 0 ... Yes (1.309)
Building and testing Git-Repository-FileHistory-0.03
Building Git-Repository-FileHistory
# Failed test 'use Git::Repository::FileHistory;'
# at t/00_compile.t line 4.
# Tried to use 'Git::Repository::FileHistory'.
# Error:  Can't locate Git/Repository/Log/Iterator.pm in @INC (you may need to install the Git::Repository::Log::Iterator module) (@INC contains: /home/tsucchi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/blib/lib /home/tsucchi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/blib/arch /home/tsucchi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/_build/lib /home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5/x86_64-linux /home/tsucc

Checking if you have ExtUtils::CBuilder 0 ... Yes (0.280212)
Checking if you have ExtUtils::MakeMaker 6.59 ... Yes (6.84)
Checking if you have Git::Repository 0 ... Yes (1.309)
Building and testing Git-Repository-FileHistory-0.03
Building Git-Repository-FileHistory
# Failed test 'use Git::Repository::FileHistory;'
# at t/00_compile.t line 4.
# Tried to use 'Git::Repository::FileHistory'.
# Error:  Can't locate Git/Repository/Log/Iterator.pm in @INC (you may need

to install the Git::Repository::Log::Iterator module) (@INC contains: /home/tsuc
chi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/blib/lib /home/ts
ucchi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/blib/arch /home
/tsucchi/.cpanm/work/1388109363.696/Git-Repository-FileHistory-0.03/_build/lib /
home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5/x86_64-linux /home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5/x86_64-linux /home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5 /home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5/x86_64-linux /home/tsucchi/.perlbrew/libs/perl-5.19@default/lib/perl5 /home/tsucchi/perl5/perlbrew/perls/perl-5.19/lib/site_perl/5.19.7/x86_64-linux /home/tsucchi/perl5/perlbrew/perls/perl-5.19/lib/site_perl/5.19.7 /home/tsucchi/perl5/perlbrew/perls/perl-5.19/lib/5.19.7/x86_64-linux /home/tsucchi/perl5/perlbrew/perls/perl-5.19/lib/5.19.7 /home/tsucchi/perl5/perlbrew/perls/perl-5.19/lib/site_perl .) at /home/tsucchi/.cpanm/work/1388109363.696/Git-Repository-FileHi
