### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ on test => sub {
     requires 'File::Temp';
     requires 'Git::Repository';
     requires 'Test::Git';
+    requires 'Test::Requires::Git', '1.005';
     requires 'Test::More';
 };
 

--- a/t/50-file.t
+++ b/t/50-file.t
@@ -2,13 +2,14 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Temp qw/tempdir/;
 use File::Spec;
 use Cwd qw/cwd abs_path/;
 use Git::Repository;
 
-has_git '1.5.0';
+test_requires_git '1.5.0';
 
 delete @ENV{qw/ GIT_DIR GIT_WORK_TREE /};
 

--- a/t/60-plugin-file.t
+++ b/t/60-plugin-file.t
@@ -2,13 +2,14 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Temp qw/tempdir/;
 use File::Spec;
 use Cwd qw/cwd abs_path/;
 use Git::Repository;
 
-has_git '1.5.0';
+test_requires_git '1.5.0';
 
 delete @ENV{qw/ GIT_DIR GIT_WORK_TREE /};
 


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
